### PR TITLE
feat: add RetryInterceptor for AppResourcesGetCommand server error handling

### DIFF
--- a/lib/src/commands/app_resources/interceptors/interceptors.dart
+++ b/lib/src/commands/app_resources/interceptors/interceptors.dart
@@ -1,0 +1,1 @@
+export 'retry_interceptor.dart';

--- a/lib/src/commands/app_resources/interceptors/retry_interceptor.dart
+++ b/lib/src/commands/app_resources/interceptors/retry_interceptor.dart
@@ -1,0 +1,64 @@
+import 'package:data/datasource/datasource.dart';
+
+class RetryInterceptor extends Interceptor {
+  RetryInterceptor({
+    required Dio dio,
+    int maxRetries = 3,
+    List<int> retryDelaysMs = const [2000, 4000, 8000],
+  })  : assert(retryDelaysMs.length >= maxRetries, 'retryDelaysMs must contain at least maxRetries entries'),
+        _dio = dio,
+        _maxRetries = maxRetries,
+        _retryDelaysMs = retryDelaysMs;
+
+  static const _retryCountKey = 'retryCount';
+
+  final Dio _dio;
+  final int _maxRetries;
+  final List<int> _retryDelaysMs;
+
+  @override
+  void onError(DioException err, ErrorInterceptorHandler handler) => _handleError(err, handler);
+
+  Future<void> _handleError(DioException err, ErrorInterceptorHandler handler) async {
+    try {
+      if (_isUnauthorized(err)) {
+        handler.reject(_buildUnauthorizedException(err));
+        return;
+      }
+
+      final retryCount = (err.requestOptions.extra[_retryCountKey] as int?) ?? 0;
+
+      if (!_shouldRetry(err) || retryCount >= _maxRetries) {
+        handler.next(err);
+        return;
+      }
+
+      await Future<void>.delayed(Duration(milliseconds: _retryDelaysMs[retryCount]));
+      err.requestOptions.extra[_retryCountKey] = retryCount + 1;
+      handler.resolve(await _dio.fetch(err.requestOptions));
+    } on DioException catch (e) {
+      handler.next(e);
+    } catch (_) {
+      handler.next(err);
+    }
+  }
+
+  bool _isUnauthorized(DioException err) => err.response?.statusCode == 401;
+
+  bool _shouldRetry(DioException err) => _isServerError(err) || _isConnectionError(err);
+
+  bool _isServerError(DioException err) => (err.response?.statusCode ?? 0) >= 500;
+
+  bool _isConnectionError(DioException err) =>
+      err.type == DioExceptionType.connectionTimeout ||
+      err.type == DioExceptionType.sendTimeout ||
+      err.type == DioExceptionType.receiveTimeout ||
+      err.type == DioExceptionType.connectionError;
+
+  DioException _buildUnauthorizedException(DioException err) => DioException(
+        requestOptions: err.requestOptions,
+        response: err.response,
+        type: err.type,
+        error: Exception('Authentication token has expired.'),
+      );
+}


### PR DESCRIPTION
- Add RetryInterceptor Dio interceptor with exponential backoff (3 retries at 2000ms, 4000ms, 8000ms)
- Retry on HTTP >= 500 (server errors) and connection/timeout errors
- Fail fast on HTTP 401 with 'Authentication token has expired.' exception
- Add interceptors barrel file
- Refactor command_runner.dart to use _buildDefaultDatasource() static method