### PR TITLE
fix: use push_notifications/firebase-service-account.json for flutterfire configure

### DIFF
--- a/lib/src/commands/app_configure/models/app_configure_context.dart
+++ b/lib/src/commands/app_configure/models/app_configure_context.dart
@@ -6,6 +6,7 @@ import 'package:mason_logger/mason_logger.dart';
 import 'package:path/path.dart' as path;
 
 import 'package:webtrit_phone_tools/src/commands/app_resources/constants/constants.dart';
+import 'package:webtrit_phone_tools/src/commands/keystore_generate/models/keystore_constants.dart' show firebaseServiceAccountRelativePath;
 import 'package:webtrit_phone_tools/src/extension/extension.dart';
 
 const _bundleIdAndroid = 'bundleIdAndroid';
@@ -13,7 +14,6 @@ const _bundleIdIos = 'bundleIdIos';
 const _keystorePath = 'keystore-path';
 const _cacheSessionDataPath = 'cache-session-data-path';
 const _directoryParameterName = '<directory>';
-const _firebaseServiceAccountFileName = 'build/google-play-service-account.json';
 
 class AppConfigureContext {
   const AppConfigureContext({
@@ -83,14 +83,14 @@ class AppConfigureContext {
       throw Exception('Permission denied for Keystore directory.');
     }
 
-    final firebaseServiceAccountPath = path.join(projectKeystorePath, _firebaseServiceAccountFileName);
-    final firebaseServiceAccount = File(firebaseServiceAccountPath).readAsStringSync().toMap();
+    final firebaseServiceAccountPath = path.join(projectKeystorePath, firebaseServiceAccountRelativePath);
+    final firebaseServiceAccountData = File(firebaseServiceAccountPath).readAsStringSync().toMap();
 
     logger
       ..info('- Firebase service account path: $firebaseServiceAccountPath')
-      ..info('- Firebase service account: $firebaseServiceAccount');
+      ..info('- Firebase service account: $firebaseServiceAccountData');
 
-    final firebaseAccountId = firebaseServiceAccount[projectIdField] as String;
+    final firebaseAccountId = firebaseServiceAccountData[projectIdField] as String;
 
     return AppConfigureContext(
       workingDirectoryPath: workingDirectoryPath,

--- a/lib/src/commands/app_setup/models/app_setup_context.dart
+++ b/lib/src/commands/app_setup/models/app_setup_context.dart
@@ -6,12 +6,12 @@ import 'package:mason_logger/mason_logger.dart';
 import 'package:path/path.dart' as path;
 
 import 'package:webtrit_phone_tools/src/commands/app_resources/constants/constants.dart';
+import 'package:webtrit_phone_tools/src/commands/keystore_generate/models/keystore_constants.dart' show firebaseServiceAccountRelativePath;
 import 'package:webtrit_phone_tools/src/extension/extension.dart';
 
 const _argPlatform = 'platform';
 const _argKeystorePath = 'keystore-path';
 const _argCacheSessionDataPath = 'cache-session-data-path';
-const _firebaseServiceAccountFileName = 'build/google-play-service-account.json';
 
 enum SetupPlatform {
   ios,
@@ -87,13 +87,13 @@ class AppSetupContext {
       throw UsageException('"$bundleIdIosField" is missing from cache session data.', '');
     }
 
-    final firebaseServiceAccountPath = path.join(projectKeystorePath, _firebaseServiceAccountFileName);
+    final firebaseServiceAccountPath = path.join(projectKeystorePath, firebaseServiceAccountRelativePath);
     if (!File(firebaseServiceAccountPath).existsSync()) {
       throw UsageException('Firebase service account not found at: $firebaseServiceAccountPath', '');
     }
 
-    final firebaseServiceAccount = File(firebaseServiceAccountPath).readAsStringSync().toMap();
-    final firebaseAccountId = firebaseServiceAccount[projectIdField] as String?;
+    final firebaseServiceAccountJson = File(firebaseServiceAccountPath).readAsStringSync().toMap();
+    final firebaseAccountId = firebaseServiceAccountJson[projectIdField] as String?;
     if (firebaseAccountId == null || firebaseAccountId.isEmpty) {
       throw UsageException('"$projectIdField" missing in Firebase service account JSON.', '');
     }

--- a/lib/src/commands/keystore_generate/models/keystore_constants.dart
+++ b/lib/src/commands/keystore_generate/models/keystore_constants.dart
@@ -21,6 +21,8 @@ const keystoreFileSubdirectory = {
 
 // Firebase
 const firebaseServiceAccount = 'firebase-service-account.json';
+const firebaseServiceAccountSubdir = 'push_notifications';
+const firebaseServiceAccountRelativePath = '$firebaseServiceAccountSubdir/$firebaseServiceAccount';
 
 // IOS
 const iosAuthKey = 'AuthKey_[key_id].p8';

--- a/test/src/commands/app_setup_command_test.dart
+++ b/test/src/commands/app_setup_command_test.dart
@@ -43,8 +43,8 @@ void main() {
     tempDir = Directory.systemTemp.createTempSync('app_setup_test_');
     keystoreDir = Directory('${tempDir.path}/keystore')..createSync();
 
-    final serviceAccountDir = Directory('${keystoreDir.path}/build')..createSync();
-    File('${serviceAccountDir.path}/google-play-service-account.json')
+    final serviceAccountDir = Directory('${keystoreDir.path}/push_notifications')..createSync();
+    File('${serviceAccountDir.path}/firebase-service-account.json')
         .writeAsStringSync(jsonEncode({'project_id': 'test-firebase-project'}));
 
     cacheFile = File('${tempDir.path}/cache_session_data.json')


### PR DESCRIPTION
## Problem

`configurator-setup` and `app-configure` were reading `build/google-play-service-account.json` as the Firebase service account. Although this SA has the **Firebase Develop Viewer** IAM role, it cannot enumerate Firebase projects via the Firebase Management API (project-level role, not org-level). As a result:

- `flutterfire configure` called without `--project` → fetched project list → got 0 results
- CLI showed interactive prompt **"Would you like to create a new Firebase project?"**
- CI job hung with no stdin to answer

## Fix

Use the dedicated Firebase SA at `push_notifications/firebase-service-account.json` (as defined in `keystoreFileSubdirectory` in `keystore_constants.dart`). This file is the correct SA for Firebase operations and has sufficient IAM access.

Added `firebaseServiceAccountRelativePath` constant to `keystore_constants.dart` so both `AppSetupContext` and `AppConfigureContext` resolve the path from a single source of truth instead of hardcoding it.

## Changes

- `keystore_constants.dart` — add `firebaseServiceAccountSubdir` + `firebaseServiceAccountRelativePath` constants
- `app_setup_context.dart` — use `firebaseServiceAccountRelativePath` instead of hardcoded `build/google-play-service-account.json`
- `app_configure_context.dart` — same fix
- `app_setup_command_test.dart` — update test fixture to match new SA path

🤖 Generated with [Claude Code](https://claude.com/claude-code)