### PR TITLE
feat(csr): add CSR generation command and keystore-init stage

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ The command creates the following structure under `<directory>/applications/<app
 ├── ssl_certificates/                    # SSL certificates for the application
 ├── AuthKey_[key_id].p8                  # iOS APNs auth key
 ├── Certificates.p12                     # iOS distribution certificate
+├── CertificateSigningRequest.certSigningRequest # CSR to upload to the Apple Developer portal
+├── CertificateSigningRequest.key        # Private key for the CSR (required to use the issued certificate)
 ├── Provision.mobileprovision            # iOS provisioning profile
 ├── upload-keystore.jks                  # Android upload keystore (JKS)
 ├── upload-keystore.p12                  # Android upload keystore (P12)
@@ -90,6 +92,17 @@ $ webtrit_phone_tools configurator-generate
 # Create metadata (Assetlinks and Apple App Site Association)
 $ webtrit_phone_tools assetlinks-generate --bundleId=<id> --appleTeamID=<id> --androidFingerprints=<sha256> --output=<path>
 
+```
+
+### Certificate Signing Request
+
+Generate an RSA private key and a certificate signing request (CSR) for the Apple Developer portal, mirroring the
+Keychain Access certificate assistant ("Request a Certificate from a Certificate Authority"). Produces
+`CertificateSigningRequest.certSigningRequest` (upload to Apple) and `CertificateSigningRequest.key` (keep it; the
+issued certificate is useless without it).
+
+```sh
+$ webtrit_phone_tools csr-generate --email=app.admin@webtrit.com --commonName="PortaDialer admin certificate request" [directory]
 ```
 
 ---

--- a/lib/src/command_runner.dart
+++ b/lib/src/command_runner.dart
@@ -67,6 +67,7 @@ class WebtritPhoneToolsCommandRunner extends CompletionCommandRunner<int> {
     addCommand(KeystoreCommitCommand(logger: _logger));
     addCommand(KeystoreVerifyCommand(logger: _logger));
     addCommand(AssetlinksGenerateCommand(logger: _logger));
+    addCommand(CsrGenerateCommand(logger: _logger));
     addCommand(UpdateCommand(logger: _logger, pubUpdater: _pubUpdater));
   }
 

--- a/lib/src/commands/commands.dart
+++ b/lib/src/commands/commands.dart
@@ -2,6 +2,7 @@ export 'app_configure/app_configure.dart';
 export 'app_resources/app_resources.dart';
 export 'app_setup/app_setup.dart';
 export 'assetlinks_generate/assetlinks_generate.dart';
+export 'csr_generate/csr_generate.dart';
 export 'keystore_commit/keystore_commit.dart';
 export 'keystore_generate/keystore_generate.dart';
 export 'keystore_init/keystore_init.dart';

--- a/lib/src/commands/csr_generate/csr_generate.dart
+++ b/lib/src/commands/csr_generate/csr_generate.dart
@@ -1,0 +1,1 @@
+export 'csr_generate_command.dart';

--- a/lib/src/commands/csr_generate/csr_generate_command.dart
+++ b/lib/src/commands/csr_generate/csr_generate_command.dart
@@ -1,0 +1,146 @@
+import 'dart:io';
+
+import 'package:args/command_runner.dart';
+import 'package:mason_logger/mason_logger.dart';
+import 'package:path/path.dart' as path;
+
+import 'package:webtrit_phone_tools/src/constants.dart';
+import 'models/models.dart';
+import 'processors/processors.dart';
+import 'runners/runners.dart';
+
+const _emailOptionName = 'email';
+const _commonNameOptionName = 'commonName';
+const _keySizeOptionName = 'keySize';
+const _createParentDirectoriesFlagName = 'createParentDirectories';
+const _directoryParameterName = '<directory>';
+const _directoryParameterDescriptionName = '$_directoryParameterName (optional)';
+
+class CsrGenerateCommand extends Command<int> {
+  CsrGenerateCommand({
+    required Logger logger,
+  }) : _logger = logger {
+    argParser
+      ..addOption(
+        _emailOptionName,
+        help: 'Email address embedded in the certificate signing request subject.',
+        mandatory: true,
+      )
+      ..addOption(
+        _commonNameOptionName,
+        help: 'Common Name (CN) embedded in the certificate signing request subject.',
+        mandatory: true,
+      )
+      ..addOption(
+        _keySizeOptionName,
+        help: 'RSA private key size in bits.',
+        defaultsTo: '$defaultKeySize',
+      )
+      ..addFlag(
+        _createParentDirectoriesFlagName,
+        help: 'Create parent directories as needed.',
+        negatable: false,
+      );
+  }
+
+  @override
+  String get name => 'csr-generate';
+
+  @override
+  String get description {
+    final buffer = StringBuffer()
+      ..writeln(
+        'Generate an RSA private key and a certificate signing request (CSR) compatible with the Apple Developer '
+        'portal, mirroring the Keychain Access certificate assistant.',
+      )
+      ..write(parameterIndent)
+      ..write(_directoryParameterDescriptionName)
+      ..write(parameterDelimiter)
+      ..writeln('Specify the directory for creating the key and CSR files.')
+      ..write(' ' * (parameterIndent.length + _directoryParameterDescriptionName.length + parameterDelimiter.length))
+      ..write('Defaults to the current working directory if not provided.');
+    return buffer.toString();
+  }
+
+  @override
+  String get invocation => '${super.invocation} [$_directoryParameterName]';
+
+  final Logger _logger;
+
+  @override
+  Future<int> run() async {
+    final CsrGenerateContext context;
+    try {
+      context = _buildContext();
+    } on UsageException catch (e) {
+      _logger.err(e.message);
+      return ExitCode.usage.code;
+    }
+
+    try {
+      final fileProcessor = CsrFileProcessor(logger: _logger)
+        ..createWorkingDirectory(
+          workingDirectoryPath: context.workingDirectoryPath,
+          createParentDirectories: context.createParentDirectories,
+        );
+
+      final opensslRunner = OpensslRunner(logger: _logger);
+      final result = opensslRunner.runGenerateCsr(
+        workingDirectoryPath: context.workingDirectoryPath,
+        context: context,
+      );
+      fileProcessor.writeOpensslLog(
+        workingDirectoryPath: context.workingDirectoryPath,
+        processResult: result,
+      );
+      if (result.exitCode != 0) {
+        return ExitCode.software.code;
+      }
+
+      _logger.success('Certificate signing request created in: ${context.workingDirectoryPath}');
+      return ExitCode.success.code;
+    } catch (e, s) {
+      _logger
+        ..err('Execution failed: $e')
+        ..detail('$s');
+      return ExitCode.software.code;
+    }
+  }
+
+  CsrGenerateContext _buildContext() {
+    final commandArgResults = argResults!;
+
+    final email = commandArgResults[_emailOptionName] as String;
+    if (email.isEmpty) {
+      throw UsageException('Option "$_emailOptionName" can not be empty.', usage);
+    }
+
+    final commonName = commandArgResults[_commonNameOptionName] as String;
+    if (commonName.isEmpty) {
+      throw UsageException('Option "$_commonNameOptionName" can not be empty.', usage);
+    }
+
+    final keySizeValue = commandArgResults[_keySizeOptionName] as String;
+    final keySize = int.tryParse(keySizeValue);
+    if (keySize == null || keySize <= 0) {
+      throw UsageException('Option "$_keySizeOptionName" must be a positive integer.', usage);
+    }
+
+    String workingDirectoryPath;
+    if (commandArgResults.rest.isEmpty) {
+      workingDirectoryPath = Directory.current.path;
+    } else if (commandArgResults.rest.length == 1) {
+      workingDirectoryPath = commandArgResults.rest[0];
+    } else {
+      throw UsageException('Only one "$_directoryParameterName" parameter can be passed.', usage);
+    }
+
+    return CsrGenerateContext(
+      workingDirectoryPath: path.normalize(workingDirectoryPath),
+      email: email,
+      commonName: commonName,
+      keySize: keySize,
+      createParentDirectories: commandArgResults[_createParentDirectoriesFlagName] as bool,
+    );
+  }
+}

--- a/lib/src/commands/csr_generate/models/csr_constants.dart
+++ b/lib/src/commands/csr_generate/models/csr_constants.dart
@@ -1,0 +1,5 @@
+const defaultKeySize = 2048;
+
+const certificateSigningRequestFileName = 'CertificateSigningRequest.certSigningRequest';
+const privateKeyFileName = 'CertificateSigningRequest.key';
+const opensslLogFileName = 'openssl.log';

--- a/lib/src/commands/csr_generate/models/csr_generate_context.dart
+++ b/lib/src/commands/csr_generate/models/csr_generate_context.dart
@@ -1,0 +1,17 @@
+class CsrGenerateContext {
+  const CsrGenerateContext({
+    required this.workingDirectoryPath,
+    required this.email,
+    required this.commonName,
+    required this.keySize,
+    required this.createParentDirectories,
+  });
+
+  final String workingDirectoryPath;
+  final String email;
+  final String commonName;
+  final int keySize;
+  final bool createParentDirectories;
+
+  String get subject => '/emailAddress=$email/CN=$commonName';
+}

--- a/lib/src/commands/csr_generate/models/models.dart
+++ b/lib/src/commands/csr_generate/models/models.dart
@@ -1,0 +1,2 @@
+export 'csr_constants.dart';
+export 'csr_generate_context.dart';

--- a/lib/src/commands/csr_generate/processors/csr_file_processor.dart
+++ b/lib/src/commands/csr_generate/processors/csr_file_processor.dart
@@ -1,0 +1,31 @@
+import 'dart:io';
+
+import 'package:mason_logger/mason_logger.dart';
+import 'package:path/path.dart' as path;
+
+import '../models/models.dart';
+
+class CsrFileProcessor {
+  const CsrFileProcessor({required this.logger});
+
+  final Logger logger;
+
+  void createWorkingDirectory({
+    required String workingDirectoryPath,
+    required bool createParentDirectories,
+  }) {
+    logger.info('Creating working directory: $workingDirectoryPath');
+    Directory(workingDirectoryPath).createSync(recursive: createParentDirectories);
+  }
+
+  void writeOpensslLog({
+    required String workingDirectoryPath,
+    required ProcessResult processResult,
+  }) {
+    logger.info('Writing openssl execution log to: $opensslLogFileName');
+    final opensslLogPath = path.join(workingDirectoryPath, opensslLogFileName);
+    File(opensslLogPath)
+      ..writeAsStringSync(processResult.stdout.toString(), flush: true)
+      ..writeAsStringSync(processResult.stderr.toString(), mode: FileMode.append, flush: true);
+  }
+}

--- a/lib/src/commands/csr_generate/processors/processors.dart
+++ b/lib/src/commands/csr_generate/processors/processors.dart
@@ -1,0 +1,1 @@
+export 'csr_file_processor.dart';

--- a/lib/src/commands/csr_generate/runners/openssl_runner.dart
+++ b/lib/src/commands/csr_generate/runners/openssl_runner.dart
@@ -1,0 +1,44 @@
+import 'dart:io';
+
+import 'package:mason_logger/mason_logger.dart';
+
+import '../models/models.dart';
+
+class OpensslRunner {
+  const OpensslRunner({required this.logger});
+
+  final Logger logger;
+
+  ProcessResult runGenerateCsr({
+    required String workingDirectoryPath,
+    required CsrGenerateContext context,
+  }) {
+    logger.info('Generating private key and certificate signing request to: $certificateSigningRequestFileName');
+    final result = Process.runSync(
+      'openssl',
+      [
+        'req',
+        '-new',
+        '-newkey',
+        'rsa:${context.keySize}',
+        '-nodes',
+        '-keyout',
+        privateKeyFileName,
+        '-out',
+        certificateSigningRequestFileName,
+        '-subj',
+        context.subject,
+      ],
+      workingDirectory: workingDirectoryPath,
+      runInShell: true,
+    );
+
+    if (result.exitCode != 0) {
+      logger
+        ..info(result.stdout.toString())
+        ..err(result.stderr.toString());
+    }
+
+    return result;
+  }
+}

--- a/lib/src/commands/csr_generate/runners/runners.dart
+++ b/lib/src/commands/csr_generate/runners/runners.dart
@@ -1,0 +1,1 @@
+export 'openssl_runner.dart';

--- a/lib/src/commands/keystore_init/keystore_init_command.dart
+++ b/lib/src/commands/keystore_init/keystore_init_command.dart
@@ -96,6 +96,14 @@ class KeystoreInitCommand extends Command<int> {
         );
       }
 
+      // Generate Apple distribution certificate signing request
+      if (((application.iosPlatformId) ?? '').isNotEmpty) {
+        await CsrGenerateRunner(logger: _logger).run(
+          keystoreProjectPath: keystoreProjectPath,
+          applicationName: application.name ?? context.applicationId,
+        );
+      }
+
       // Prepare base credentials template for ios auto deploy
       projectProcessor.writeIosCredentialsTemplate(
         keystoreProjectPath: keystoreProjectPath,

--- a/lib/src/commands/keystore_init/runners/csr_generate_runner.dart
+++ b/lib/src/commands/keystore_init/runners/csr_generate_runner.dart
@@ -1,0 +1,29 @@
+import 'package:args/command_runner.dart';
+import 'package:mason_logger/mason_logger.dart';
+
+import 'package:webtrit_phone_tools/src/commands/csr_generate/csr_generate.dart';
+
+const _appleDeveloperAccountEmail = 'app.admin@webtrit.com';
+
+class CsrGenerateRunner {
+  const CsrGenerateRunner({required this.logger});
+
+  final Logger logger;
+
+  Future<int?> run({
+    required String keystoreProjectPath,
+    required String applicationName,
+  }) async {
+    logger.info('Running csr-generate sub-command');
+    final commandRunner = CommandRunner<int>('tool', 'A tool to manage keystore')
+      ..addCommand(CsrGenerateCommand(logger: logger));
+    return commandRunner.run([
+      'csr-generate',
+      '--email',
+      _appleDeveloperAccountEmail,
+      '--commonName',
+      '$applicationName admin certificate request',
+      keystoreProjectPath,
+    ]);
+  }
+}

--- a/lib/src/commands/keystore_init/runners/runners.dart
+++ b/lib/src/commands/keystore_init/runners/runners.dart
@@ -1,3 +1,4 @@
 export 'assetlinks_generate_runner.dart';
+export 'csr_generate_runner.dart';
 export 'keystore_generate_runner.dart';
 export 'keytool_runner.dart';

--- a/test/src/commands/csr_generate_command_test.dart
+++ b/test/src/commands/csr_generate_command_test.dart
@@ -1,0 +1,68 @@
+import 'dart:io';
+
+import 'package:args/command_runner.dart';
+import 'package:mason_logger/mason_logger.dart';
+import 'package:path/path.dart' as path;
+import 'package:test/test.dart';
+
+import 'package:webtrit_phone_tools/src/commands/csr_generate/csr_generate.dart';
+
+void main() {
+  late Logger logger;
+  late CommandRunner<int> commandRunner;
+
+  setUp(() {
+    logger = Logger();
+    commandRunner = CommandRunner<int>('test', 'Test for CsrGenerateCommand')
+      ..addCommand(CsrGenerateCommand(logger: logger));
+  });
+
+  test('should generate a private key and a certificate signing request', () async {
+    final outputDirectory = Directory.systemTemp.createTempSync();
+    final result = await commandRunner.run([
+      'csr-generate',
+      '--email',
+      'app.admin@webtrit.com',
+      '--commonName',
+      'PortaDialer admin certificate request',
+      outputDirectory.path,
+    ]);
+
+    expect(result, equals(0));
+    expect(
+      File(path.join(outputDirectory.path, 'CertificateSigningRequest.certSigningRequest')).existsSync(),
+      isTrue,
+    );
+    expect(File(path.join(outputDirectory.path, 'CertificateSigningRequest.key')).existsSync(), isTrue);
+  });
+
+  test('should show usage error when email is empty', () async {
+    final outputDirectory = Directory.systemTemp.createTempSync();
+    final result = await commandRunner.run([
+      'csr-generate',
+      '--email',
+      '',
+      '--commonName',
+      'PortaDialer admin certificate request',
+      outputDirectory.path,
+    ]);
+
+    expect(result, equals(64)); // ExitCode.usage.code
+  });
+
+  test('should show usage error when keySize is not a positive integer', () async {
+    final outputDirectory = Directory.systemTemp.createTempSync();
+    final result = await commandRunner.run([
+      'csr-generate',
+      '--email',
+      'app.admin@webtrit.com',
+      '--commonName',
+      'PortaDialer admin certificate request',
+      '--keySize',
+      'abc',
+      outputDirectory.path,
+    ]);
+
+    expect(result, equals(64)); // ExitCode.usage.code
+  });
+}

--- a/test/src/utils/keystore_readme_updater_test.dart
+++ b/test/src/utils/keystore_readme_updater_test.dart
@@ -40,7 +40,7 @@ void main() {
       const applicationId = 'testAppId';
 
       final readmeFilePath = path.join(tempDir.path, 'README.md');
-      const initialContent = '## Keystore folders\n\n---\n';
+      const initialContent = '# Keystore accounts\n\n---\n';
       File(readmeFilePath).writeAsStringSync(initialContent);
 
       await readmeUpdater.addApplicationRecord(tempDir.path, applicationName, applicationId);


### PR DESCRIPTION
## Overview

Adds a `csr-generate` command that reproduces the macOS Keychain Access "Request a Certificate from a Certificate Authority" flow via `openssl`, and wires it into `keystore-init` as a stage.

## csr-generate

```sh
webtrit_phone_tools csr-generate --email=<email> --commonName=<cn> [directory]
```

Generates an RSA private key and a PKCS#10 certificate signing request:
- `CertificateSigningRequest.certSigningRequest` - upload to the Apple Developer portal
- `CertificateSigningRequest.key` - private key, required to use the issued certificate
- `openssl.log`

Follows the Orchestrator Pattern: command + context + `OpensslRunner` + `CsrFileProcessor`. Key size defaults to 2048 (`--keySize`). Input validation returns usage exit code; openssl failure returns software exit code.

## keystore-init stage

When the fetched application has an `iosPlatformId`, `keystore-init` now generates the Apple distribution CSR into the keystore project root (alongside `Certificates.p12`), via a `CsrGenerateRunner` wrapper. Email is fixed to the WebTrit Apple Developer account; the common name is derived from the application name.

## Notes

- Includes a separate commit fixing a stale `KeystoreReadmeUpdater` test fixture (section heading drift) so the suite is green.
- Generates a fresh per-app CSR/key on every `keystore-init`; can be gated behind a flag if shared distribution certs are preferred.