### PR TITLE
feat(csr): add csr-finalize command to build p12 and write code signing identity

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,15 @@ issued certificate is useless without it).
 $ webtrit_phone_tools csr-generate --email=app.admin@webtrit.com --commonName="PortaDialer admin certificate request" [directory]
 ```
 
+Once Apple issues the certificate, download the `.cer` and finalize it with `csr-finalize`. It bundles the
+certificate with the private key (`CertificateSigningRequest.key`) into `Certificates.p12`, computes the 40-character
+code signing identity (SHA-1 fingerprint), and writes it to `upload-store-connect-metadata.json` as
+`code-signing-identity`.
+
+```sh
+$ webtrit_phone_tools csr-finalize --cert=ios_distribution.cer [--password=<p12-password>] [directory]
+```
+
 ---
 
 ## Documentation

--- a/lib/src/command_runner.dart
+++ b/lib/src/command_runner.dart
@@ -68,6 +68,7 @@ class WebtritPhoneToolsCommandRunner extends CompletionCommandRunner<int> {
     addCommand(KeystoreVerifyCommand(logger: _logger));
     addCommand(AssetlinksGenerateCommand(logger: _logger));
     addCommand(CsrGenerateCommand(logger: _logger));
+    addCommand(CsrFinalizeCommand(logger: _logger));
     addCommand(UpdateCommand(logger: _logger, pubUpdater: _pubUpdater));
   }
 

--- a/lib/src/commands/commands.dart
+++ b/lib/src/commands/commands.dart
@@ -2,6 +2,7 @@ export 'app_configure/app_configure.dart';
 export 'app_resources/app_resources.dart';
 export 'app_setup/app_setup.dart';
 export 'assetlinks_generate/assetlinks_generate.dart';
+export 'csr_finalize/csr_finalize.dart';
 export 'csr_generate/csr_generate.dart';
 export 'keystore_commit/keystore_commit.dart';
 export 'keystore_generate/keystore_generate.dart';

--- a/lib/src/commands/csr_finalize/csr_finalize.dart
+++ b/lib/src/commands/csr_finalize/csr_finalize.dart
@@ -1,0 +1,1 @@
+export 'csr_finalize_command.dart';

--- a/lib/src/commands/csr_finalize/csr_finalize_command.dart
+++ b/lib/src/commands/csr_finalize/csr_finalize_command.dart
@@ -1,0 +1,166 @@
+import 'dart:io';
+
+import 'package:args/command_runner.dart';
+import 'package:mason_logger/mason_logger.dart';
+import 'package:path/path.dart' as path;
+
+import 'package:webtrit_phone_tools/src/commands/csr_generate/models/models.dart';
+import 'package:webtrit_phone_tools/src/commands/keystore_generate/models/models.dart';
+import 'package:webtrit_phone_tools/src/constants.dart';
+
+import 'models/models.dart';
+import 'processors/processors.dart';
+import 'runners/runners.dart';
+
+const _certOptionName = 'cert';
+const _keyOptionName = 'key';
+const _outputOptionName = 'output';
+const _passwordOptionName = 'password';
+const _directoryParameterName = '<directory>';
+const _directoryParameterDescriptionName = '$_directoryParameterName (optional)';
+
+class CsrFinalizeCommand extends Command<int> {
+  CsrFinalizeCommand({
+    required Logger logger,
+  }) : _logger = logger {
+    argParser
+      ..addOption(
+        _certOptionName,
+        help: 'Path to the certificate (.cer) downloaded from the Apple Developer portal.',
+        mandatory: true,
+      )
+      ..addOption(
+        _keyOptionName,
+        help: 'Private key file generated alongside the certificate signing request.',
+        defaultsTo: privateKeyFileName,
+      )
+      ..addOption(
+        _outputOptionName,
+        help: 'PKCS12 bundle file to create.',
+        defaultsTo: iosCertificates,
+      )
+      ..addOption(
+        _passwordOptionName,
+        help: 'Export password for the PKCS12 bundle.',
+        defaultsTo: '',
+      );
+  }
+
+  @override
+  String get name => 'csr-finalize';
+
+  @override
+  String get description {
+    final buffer = StringBuffer()
+      ..writeln(
+        'Bundle a downloaded Apple certificate with its private key into a PKCS12 file, compute the code signing '
+        'identity, and write it to the App Store Connect metadata.',
+      )
+      ..write(parameterIndent)
+      ..write(_directoryParameterDescriptionName)
+      ..write(parameterDelimiter)
+      ..writeln('Directory holding the private key, metadata, and output bundle.')
+      ..write(' ' * (parameterIndent.length + _directoryParameterDescriptionName.length + parameterDelimiter.length))
+      ..write('Defaults to the current working directory if not provided.');
+    return buffer.toString();
+  }
+
+  @override
+  String get invocation => '${super.invocation} [$_directoryParameterName]';
+
+  final Logger _logger;
+
+  @override
+  Future<int> run() async {
+    final CsrFinalizeContext context;
+    try {
+      context = _buildContext();
+    } on UsageException catch (e) {
+      _logger.err(e.message);
+      return ExitCode.usage.code;
+    }
+
+    final tempDirectory = Directory.systemTemp.createTempSync('csr_finalize');
+    final pemPath = path.join(tempDirectory.path, 'certificate.pem');
+    try {
+      final opensslRunner = OpensslRunner(logger: _logger);
+
+      if (!opensslRunner.convertCertificateToPem(certificatePath: context.certificatePath, pemPath: pemPath)) {
+        return ExitCode.software.code;
+      }
+
+      final pkcs12Result = opensslRunner.buildPkcs12(
+        pemPath: pemPath,
+        privateKeyPath: context.privateKeyPath,
+        pkcs12Path: context.pkcs12Path,
+        password: context.password,
+      );
+      if (pkcs12Result.exitCode != 0) {
+        return ExitCode.software.code;
+      }
+
+      final identity = opensslRunner.extractCodeSigningIdentity(pemPath: pemPath);
+      if (identity == null) {
+        return ExitCode.software.code;
+      }
+
+      MetadataProcessor(logger: _logger).writeCodeSigningIdentity(
+        metadataPath: context.metadataPath,
+        identity: identity,
+      );
+
+      _logger
+        ..success('PKCS12 bundle created: ${context.pkcs12Path}')
+        ..success('Code signing identity: $identity');
+      return ExitCode.success.code;
+    } catch (e, s) {
+      _logger
+        ..err('Execution failed: $e')
+        ..detail('$s');
+      return ExitCode.software.code;
+    } finally {
+      tempDirectory.deleteSync(recursive: true);
+    }
+  }
+
+  CsrFinalizeContext _buildContext() {
+    final commandArgResults = argResults!;
+
+    final certificate = commandArgResults[_certOptionName] as String;
+    if (certificate.isEmpty) {
+      throw UsageException('Option "$_certOptionName" can not be empty.', usage);
+    }
+
+    String workingDirectoryPath;
+    if (commandArgResults.rest.isEmpty) {
+      workingDirectoryPath = Directory.current.path;
+    } else if (commandArgResults.rest.length == 1) {
+      workingDirectoryPath = commandArgResults.rest[0];
+    } else {
+      throw UsageException('Only one "$_directoryParameterName" parameter can be passed.', usage);
+    }
+
+    final certificatePath = _resolvePath(workingDirectoryPath, certificate);
+    final privateKeyPath = _resolvePath(workingDirectoryPath, commandArgResults[_keyOptionName] as String);
+    final pkcs12Path = _resolvePath(workingDirectoryPath, commandArgResults[_outputOptionName] as String);
+    final metadataPath = path.join(workingDirectoryPath, iosCredentials);
+
+    if (!File(certificatePath).existsSync()) {
+      throw UsageException('Certificate not found: $certificatePath', usage);
+    }
+    if (!File(privateKeyPath).existsSync()) {
+      throw UsageException('Private key not found: $privateKeyPath', usage);
+    }
+
+    return CsrFinalizeContext(
+      certificatePath: certificatePath,
+      privateKeyPath: privateKeyPath,
+      pkcs12Path: pkcs12Path,
+      metadataPath: metadataPath,
+      password: commandArgResults[_passwordOptionName] as String,
+    );
+  }
+
+  String _resolvePath(String workingDirectoryPath, String target) =>
+      path.isAbsolute(target) ? target : path.join(workingDirectoryPath, target);
+}

--- a/lib/src/commands/csr_finalize/models/csr_finalize_constants.dart
+++ b/lib/src/commands/csr_finalize/models/csr_finalize_constants.dart
@@ -1,0 +1,1 @@
+const codeSigningIdentityKey = 'code-signing-identity';

--- a/lib/src/commands/csr_finalize/models/csr_finalize_context.dart
+++ b/lib/src/commands/csr_finalize/models/csr_finalize_context.dart
@@ -1,0 +1,15 @@
+class CsrFinalizeContext {
+  const CsrFinalizeContext({
+    required this.certificatePath,
+    required this.privateKeyPath,
+    required this.pkcs12Path,
+    required this.metadataPath,
+    required this.password,
+  });
+
+  final String certificatePath;
+  final String privateKeyPath;
+  final String pkcs12Path;
+  final String metadataPath;
+  final String password;
+}

--- a/lib/src/commands/csr_finalize/models/models.dart
+++ b/lib/src/commands/csr_finalize/models/models.dart
@@ -1,0 +1,2 @@
+export 'csr_finalize_constants.dart';
+export 'csr_finalize_context.dart';

--- a/lib/src/commands/csr_finalize/processors/metadata_processor.dart
+++ b/lib/src/commands/csr_finalize/processors/metadata_processor.dart
@@ -1,0 +1,37 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:mason_logger/mason_logger.dart';
+import 'package:path/path.dart' as path;
+
+import '../models/models.dart';
+
+class MetadataProcessor {
+  const MetadataProcessor({required this.logger});
+
+  final Logger logger;
+
+  void writeCodeSigningIdentity({
+    required String metadataPath,
+    required String identity,
+  }) {
+    logger.info('Writing $codeSigningIdentityKey to: ${path.basename(metadataPath)}');
+    final metadata = _readMetadata(metadataPath);
+    metadata[codeSigningIdentityKey] = identity;
+
+    final content = (StringBuffer()..writeln(const JsonEncoder.withIndent('  ').convert(metadata))).toString();
+    File(metadataPath).writeAsStringSync(content, flush: true);
+  }
+
+  Map<String, dynamic> _readMetadata(String metadataPath) {
+    final file = File(metadataPath);
+    if (!file.existsSync()) {
+      return <String, dynamic>{};
+    }
+    final content = file.readAsStringSync().trim();
+    if (content.isEmpty) {
+      return <String, dynamic>{};
+    }
+    return jsonDecode(content) as Map<String, dynamic>;
+  }
+}

--- a/lib/src/commands/csr_finalize/processors/processors.dart
+++ b/lib/src/commands/csr_finalize/processors/processors.dart
@@ -1,0 +1,1 @@
+export 'metadata_processor.dart';

--- a/lib/src/commands/csr_finalize/runners/openssl_runner.dart
+++ b/lib/src/commands/csr_finalize/runners/openssl_runner.dart
@@ -1,0 +1,85 @@
+import 'dart:io';
+
+import 'package:mason_logger/mason_logger.dart';
+
+class OpensslRunner {
+  const OpensslRunner({required this.logger});
+
+  final Logger logger;
+
+  bool convertCertificateToPem({
+    required String certificatePath,
+    required String pemPath,
+  }) {
+    logger.info('Converting certificate to PEM');
+    for (final inputFormat in const ['DER', 'PEM']) {
+      final result = Process.runSync(
+        'openssl',
+        ['x509', '-inform', inputFormat, '-in', certificatePath, '-out', pemPath],
+        runInShell: true,
+      );
+      if (result.exitCode == 0) {
+        return true;
+      }
+    }
+    logger.err('Failed to read certificate: $certificatePath');
+    return false;
+  }
+
+  ProcessResult buildPkcs12({
+    required String pemPath,
+    required String privateKeyPath,
+    required String pkcs12Path,
+    required String password,
+  }) {
+    logger.info('Building PKCS12 bundle to: $pkcs12Path');
+    final result = Process.runSync(
+      'openssl',
+      [
+        'pkcs12',
+        '-export',
+        '-inkey',
+        privateKeyPath,
+        '-in',
+        pemPath,
+        '-out',
+        pkcs12Path,
+        '-passout',
+        'pass:$password',
+      ],
+      runInShell: true,
+    );
+
+    if (result.exitCode != 0) {
+      logger
+        ..info(result.stdout.toString())
+        ..err(result.stderr.toString());
+    }
+
+    return result;
+  }
+
+  String? extractCodeSigningIdentity({required String pemPath}) {
+    final result = Process.runSync(
+      'openssl',
+      ['x509', '-in', pemPath, '-noout', '-fingerprint', '-sha1'],
+      runInShell: true,
+    );
+
+    if (result.exitCode != 0) {
+      logger.err('Failed to compute certificate fingerprint: ${result.stderr}');
+      return null;
+    }
+
+    final output = result.stdout.toString();
+    final delimiterIndex = output.indexOf('=');
+    if (delimiterIndex == -1) {
+      logger.err('SHA1 fingerprint not found in the output.');
+      return null;
+    }
+
+    final identity =
+        output.substring(delimiterIndex + 1).replaceAll(':', '').replaceAll(RegExp(r'\s'), '').toUpperCase();
+    return identity.isEmpty ? null : identity;
+  }
+}

--- a/lib/src/commands/csr_finalize/runners/runners.dart
+++ b/lib/src/commands/csr_finalize/runners/runners.dart
@@ -1,0 +1,1 @@
+export 'openssl_runner.dart';

--- a/test/src/commands/csr_finalize_command_test.dart
+++ b/test/src/commands/csr_finalize_command_test.dart
@@ -1,0 +1,74 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:args/command_runner.dart';
+import 'package:mason_logger/mason_logger.dart';
+import 'package:path/path.dart' as path;
+import 'package:test/test.dart';
+
+import 'package:webtrit_phone_tools/src/commands/csr_finalize/csr_finalize.dart';
+
+void main() {
+  late Logger logger;
+  late CommandRunner<int> commandRunner;
+
+  setUp(() {
+    logger = Logger();
+    commandRunner = CommandRunner<int>('test', 'Test for CsrFinalizeCommand')
+      ..addCommand(CsrFinalizeCommand(logger: logger));
+  });
+
+  Directory createKeystoreDirectory() {
+    final directory = Directory.systemTemp.createTempSync();
+    final pemPath = path.join(directory.path, 'certificate.pem');
+    final keyPath = path.join(directory.path, 'CertificateSigningRequest.key');
+    Process.runSync(
+      'openssl',
+      [
+        'req', '-new', '-newkey', 'rsa:2048', '-nodes', '-keyout', keyPath, //
+        '-x509', '-days', '1', '-subj', '/CN=iPhone Distribution: Test', '-out', pemPath,
+      ],
+      runInShell: true,
+    );
+    Process.runSync(
+      'openssl',
+      ['x509', '-in', pemPath, '-outform', 'DER', '-out', path.join(directory.path, 'ios_distribution.cer')],
+      runInShell: true,
+    );
+    File(path.join(directory.path, 'upload-store-connect-metadata.json'))
+        .writeAsStringSync('{"bundleId": "com.example.app"}');
+    return directory;
+  }
+
+  test('should build a PKCS12 bundle and write the code signing identity', () async {
+    final directory = createKeystoreDirectory();
+    final result = await commandRunner.run([
+      'csr-finalize',
+      '--cert',
+      'ios_distribution.cer',
+      directory.path,
+    ]);
+
+    expect(result, equals(0));
+    expect(File(path.join(directory.path, 'Certificates.p12')).existsSync(), isTrue);
+
+    final metadata = jsonDecode(
+      File(path.join(directory.path, 'upload-store-connect-metadata.json')).readAsStringSync(),
+    ) as Map<String, dynamic>;
+    expect(metadata['bundleId'], equals('com.example.app'));
+    expect(metadata['code-signing-identity'], matches(RegExp(r'^[0-9A-F]{40}$')));
+  });
+
+  test('should show usage error when the certificate is missing', () async {
+    final directory = createKeystoreDirectory();
+    final result = await commandRunner.run([
+      'csr-finalize',
+      '--cert',
+      'does_not_exist.cer',
+      directory.path,
+    ]);
+
+    expect(result, equals(64)); // ExitCode.usage.code
+    expect(File(path.join(directory.path, 'Certificates.p12')).existsSync(), isFalse);
+  });
+}


### PR DESCRIPTION
## Overview

Adds a `csr-finalize` command that completes the Apple signing certificate lifecycle started by `csr-generate`. Given the `.cer` issued by Apple and the private key generated alongside the CSR, it produces the distribution `Certificates.p12`, computes the 40-character code signing identity, and records it in the App Store Connect metadata - all from the CLI, no Keychain round-trip.

## Usage

```sh
webtrit_phone_tools csr-finalize --cert=ios_distribution.cer [--password=<p12-password>] [directory]
```

Steps performed:
1. Converts the certificate (`.cer`, DER or PEM) to PEM.
2. Bundles it with the private key (`CertificateSigningRequest.key`) into `Certificates.p12`.
3. Computes the code signing identity (SHA-1 fingerprint, 40 hex chars) - the same value `security find-identity -v -p codesigning` prints.
4. Writes it into `upload-store-connect-metadata.json` as `code-signing-identity`, preserving existing keys.

Options: `--cert` (mandatory), `--key` (defaults to `CertificateSigningRequest.key`), `--output` (defaults to `Certificates.p12`), `--password` (defaults to empty). Paths resolve relative to the optional `[directory]` (defaults to the current directory).

## Notes

- Follows the Orchestrator Pattern: command + context + `OpensslRunner` (PEM conversion, p12 build, fingerprint) + `MetadataProcessor` (JSON merge). Reuses the existing file-name constants (`privateKeyFileName`, `iosCertificates`, `iosCredentials`).
- End-to-end test generates a matching key/cert pair, runs the command, and asserts the p12 and a 40-char identity in the metadata.