### PR TITLE
fix(csr): produce macOS-importable Certificates.p12 (empty-password MAC)

### DIFF
--- a/lib/src/commands/csr_finalize/runners/openssl_runner.dart
+++ b/lib/src/commands/csr_finalize/runners/openssl_runner.dart
@@ -38,6 +38,12 @@ class OpensslRunner {
       [
         'pkcs12',
         '-export',
+        // OpenSSL 3.x defaults to PBES2/AES-256-CBC with a SHA-256 MAC, which
+        // macOS `security import` (used by fastlane during the iOS archive)
+        // cannot read and rejects with "MAC verification failed during PKCS12
+        // import (wrong password?)". `-legacy` emits the older
+        // PBE-SHA1-3DES/RC2 + SHA-1 MAC format that the macOS keychain accepts.
+        '-legacy',
         '-inkey',
         privateKeyPath,
         '-in',


### PR DESCRIPTION
## Problem

`csr-finalize` (#46) builds `Certificates.p12` with `openssl pkcs12 -export`. The resulting bundle is rejected by macOS `security import` — which is what `yukiarrr/ios-build-action` runs during the iOS archive:

```
security: SecKeychainItemImport: MAC verification failed during PKCS12 import (wrong password?)
```

…and the archive then fails with `No certificate ... matching <identity> found` → `** ARCHIVE FAILED **`. This broke the iOS build for application `BOgdsBdvnRGTjhETflKH` (Malawi Telecommunications).

## Root cause (reproduced on macOS 26)

Two separate incompatibilities, both required to be fixed:

1. **Cipher** — OpenSSL 3.x defaults to PBES2/AES-256-CBC, which macOS `security import` cannot read at all (even with a correct password). Needs `-legacy` (RC2-40 / 3DES).
2. **MAC for empty passwords** — OpenSSL and Apple's SecurityFramework derive the PKCS12 MAC differently when the password is empty. An `openssl`-written **empty-password** bundle fails MAC verification on macOS *regardless of cipher or MAC iteration count*. The existing 23 apps work because their p12 were exported by Keychain Access (Apple MAC).

| Cipher | Password | `security import` (macOS 26) |
|---|---|---|
| AES (OpenSSL default) | any | ❌ MAC verification failed |
| legacy | empty | ❌ MAC verification failed |
| legacy | non-empty | ✅ imported |
| **re-export via `security`** | **empty** | ✅ imported |

## Fix

On macOS, build an intermediate `-legacy` bundle with a throwaway password (the keychain can't read an empty-password OpenSSL bundle), import it into a temporary keychain, and re-export it with `security export`. The re-exported bundle carries the Apple MAC layout (MAC iteration 1) the other apps use and imports with an empty password. Off macOS, it falls back to the OpenSSL bundle and logs a warning.

- New `KeychainRunner` performs the create → import → export → delete-keychain round-trip (temp keychain, always cleaned up).
- `OpensslRunner.buildPkcs12` now passes `-legacy`.
- The `csr-finalize` test asserts the generated bundle imports with an empty password via `security import` on macOS. Full suite green (33 tests).

## Note on existing certs

Fixes generation going forward. Already-generated p12 (e.g. `webtrit_phone_keystores/applications/BOgdsBdvnRGTjhETflKH/`) were re-exported once via the same `security` round-trip and committed separately.