### PR TITLE
fix(csr): produce macOS-importable Certificates.p12 (empty-password MAC)

### DIFF
--- a/lib/src/commands/csr_finalize/csr_finalize_command.dart
+++ b/lib/src/commands/csr_finalize/csr_finalize_command.dart
@@ -89,14 +89,43 @@ class CsrFinalizeCommand extends Command<int> {
         return ExitCode.software.code;
       }
 
+      // OpenSSL and Apple's SecurityFramework disagree on the PKCS12 MAC for
+      // empty passwords, so a bundle written straight to disk by OpenSSL is
+      // rejected by macOS `security import`. On macOS, build an intermediate
+      // bundle (non-empty password, so the keychain can read it) and re-export
+      // it through the keychain to get a macOS-compatible MAC. Elsewhere fall
+      // back to the OpenSSL bundle directly.
+      final repackageViaKeychain = Platform.isMacOS;
+      final bundlePath = repackageViaKeychain ? path.join(tempDirectory.path, 'intermediate.p12') : context.pkcs12Path;
+      final bundlePassword = repackageViaKeychain ? intermediatePkcs12Password : context.password;
+
       final pkcs12Result = opensslRunner.buildPkcs12(
         pemPath: pemPath,
         privateKeyPath: context.privateKeyPath,
-        pkcs12Path: context.pkcs12Path,
-        password: context.password,
+        pkcs12Path: bundlePath,
+        password: bundlePassword,
       );
       if (pkcs12Result.exitCode != 0) {
         return ExitCode.software.code;
+      }
+
+      if (repackageViaKeychain) {
+        final repackaged = KeychainRunner(logger: _logger).repackage(
+          sourcePkcs12Path: bundlePath,
+          sourcePassword: bundlePassword,
+          outputPkcs12Path: context.pkcs12Path,
+          outputPassword: context.password,
+          workDirectory: tempDirectory.path,
+        );
+        if (!repackaged) {
+          return ExitCode.software.code;
+        }
+      } else {
+        _logger.warn(
+          'Not running on macOS: wrote the PKCS12 bundle directly with OpenSSL. '
+          'With an empty password it may be rejected by macOS `security import` '
+          '("MAC verification failed"); generate on macOS or pass a non-empty --password.',
+        );
       }
 
       final identity = opensslRunner.extractCodeSigningIdentity(pemPath: pemPath);

--- a/lib/src/commands/csr_finalize/models/csr_finalize_constants.dart
+++ b/lib/src/commands/csr_finalize/models/csr_finalize_constants.dart
@@ -1,1 +1,7 @@
 const codeSigningIdentityKey = 'code-signing-identity';
+
+/// Throwaway password for the intermediate OpenSSL bundle that is imported into
+/// the keychain before re-export. macOS `security import` cannot read an
+/// empty-password OpenSSL bundle, so the intermediate must use a non-empty
+/// password; the final bundle's password is controlled by `--password`.
+const intermediatePkcs12Password = 'csr-finalize-intermediate';

--- a/lib/src/commands/csr_finalize/runners/keychain_runner.dart
+++ b/lib/src/commands/csr_finalize/runners/keychain_runner.dart
@@ -1,0 +1,63 @@
+import 'dart:io';
+
+import 'package:mason_logger/mason_logger.dart';
+import 'package:path/path.dart' as path;
+
+/// Re-packages a PKCS12 bundle through the macOS keychain so the resulting file
+/// carries a MAC that `security import` accepts.
+///
+/// OpenSSL 3.x and Apple's SecurityFramework compute the PKCS12 MAC differently
+/// for empty passwords, so a bundle written directly by `openssl pkcs12 -export`
+/// with an empty password is rejected by macOS with
+/// "MAC verification failed during PKCS12 import (wrong password?)". Importing
+/// the bundle into a throwaway keychain and exporting it again with `security`
+/// produces the same MAC layout (MAC iteration 1) the other applications use,
+/// which imports cleanly with an empty password.
+///
+/// macOS only — `security` is not available on other platforms.
+class KeychainRunner {
+  const KeychainRunner({required this.logger});
+
+  final Logger logger;
+
+  /// Imports [sourcePkcs12Path] (protected by [sourcePassword]) into a temporary
+  /// keychain and re-exports it to [outputPkcs12Path] under [outputPassword].
+  /// The temporary keychain is always removed. Returns `false` on failure.
+  bool repackage({
+    required String sourcePkcs12Path,
+    required String sourcePassword,
+    required String outputPkcs12Path,
+    required String outputPassword,
+    required String workDirectory,
+  }) {
+    final keychainPath = path.join(workDirectory, 'csr_finalize.keychain');
+    const keychainPassword = 'csr-finalize';
+
+    try {
+      if (!_run('create-keychain', ['create-keychain', '-p', keychainPassword, keychainPath])) return false;
+      if (!_run('unlock-keychain', ['unlock-keychain', '-p', keychainPassword, keychainPath])) return false;
+      // -A grants every tool access so the later export does not prompt.
+      if (!_run('import', ['import', sourcePkcs12Path, '-k', keychainPath, '-P', sourcePassword, '-A'])) return false;
+
+      final output = File(outputPkcs12Path);
+      if (output.existsSync()) output.deleteSync();
+
+      return _run('export', [
+        'export', '-k', keychainPath, '-t', 'identities', '-f', 'pkcs12', '-P', outputPassword, '-o', outputPkcs12Path, //
+      ]);
+    } finally {
+      Process.runSync('security', ['delete-keychain', keychainPath], runInShell: true);
+    }
+  }
+
+  bool _run(String step, List<String> arguments) {
+    final result = Process.runSync('security', arguments, runInShell: true);
+    if (result.exitCode != 0) {
+      logger
+        ..info(result.stdout.toString())
+        ..err('security $step failed: ${result.stderr}');
+      return false;
+    }
+    return true;
+  }
+}

--- a/lib/src/commands/csr_finalize/runners/runners.dart
+++ b/lib/src/commands/csr_finalize/runners/runners.dart
@@ -1,1 +1,2 @@
+export 'keychain_runner.dart';
 export 'openssl_runner.dart';

--- a/test/src/commands/csr_finalize_command_test.dart
+++ b/test/src/commands/csr_finalize_command_test.dart
@@ -50,7 +50,23 @@ void main() {
     ]);
 
     expect(result, equals(0));
-    expect(File(path.join(directory.path, 'Certificates.p12')).existsSync(), isTrue);
+    final pkcs12Path = path.join(directory.path, 'Certificates.p12');
+    expect(File(pkcs12Path).existsSync(), isTrue);
+
+    // On macOS the bundle must import with an empty password — this is exactly
+    // what `yukiarrr/ios-build-action` does, and what the OpenSSL-only bundle
+    // failed with ("MAC verification failed during PKCS12 import").
+    if (Platform.isMacOS) {
+      final keychainPath = path.join(directory.path, 'verify.keychain');
+      Process.runSync('security', ['create-keychain', '-p', 'verify', keychainPath], runInShell: true);
+      final import = Process.runSync(
+        'security',
+        ['import', pkcs12Path, '-k', keychainPath, '-P', ''],
+        runInShell: true,
+      );
+      Process.runSync('security', ['delete-keychain', keychainPath], runInShell: true);
+      expect(import.exitCode, equals(0), reason: 'security import failed: ${import.stderr}');
+    }
 
     final metadata = jsonDecode(
       File(path.join(directory.path, 'upload-store-connect-metadata.json')).readAsStringSync(),


### PR DESCRIPTION
Follow-up to #47, which added `-legacy` to `openssl pkcs12 -export`. That is **necessary but not sufficient**.

## Problem

The p12 from `csr-finalize` is still rejected by macOS `security import` (run by `yukiarrr/ios-build-action` during the iOS archive):

```
security: SecKeychainItemImport: MAC verification failed during PKCS12 import (wrong password?)
```

→ `No certificate ... matching <identity> found` → `** ARCHIVE FAILED **`. This broke the iOS build for app `BOgdsBdvnRGTjhETflKH` (Malawi Telecommunications).

## Root cause (reproduced on macOS 26)

Two independent incompatibilities:

1. **Cipher** — OpenSSL 3.x defaults to PBES2/AES-256-CBC, unreadable by macOS `security import`. Fixed by `-legacy` in #47.
2. **MAC for empty passwords** — OpenSSL and Apple's SecurityFramework derive the PKCS12 MAC differently for empty passwords, so an `openssl`-written **empty-password** bundle fails MAC verification *regardless of cipher or MAC iteration*. The existing apps work because their p12 came from Keychain Access (Apple MAC).

| Cipher | Password | `security import` (macOS 26) |
|---|---|---|
| AES | any | ❌ |
| legacy | empty | ❌ |
| legacy | non-empty | ✅ |
| **re-export via `security`** | **empty** | ✅ |

## Fix

On macOS: build an intermediate `-legacy` bundle with a throwaway password (the keychain can't read an empty-password OpenSSL bundle), import it into a temporary keychain, and re-export with `security export`. The result carries the Apple MAC layout (MAC iteration 1) used by every other app and imports with an empty password. Off macOS: fall back to the OpenSSL bundle + warning.

- New `KeychainRunner` does create → import → export → delete-keychain (temp keychain, always cleaned up).
- `csr-finalize` test now asserts the bundle imports via `security import -P ""` on macOS.
- `dart analyze` clean; full suite green (33 tests).

## Existing certs

Already-generated p12 (e.g. the mtlanywhere one) were re-exported once via the same `security` round-trip and committed to `webtrit_phone_keystores` separately.